### PR TITLE
Robustify the code for NFS weirdness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/pkhuong/kismet-cache"
 derivative = "2"
 extendhash = "1"
 filetime = "0.2"
+libc = "0.2"
 rand = "0.8"
 tempfile = "3"
 

--- a/src/benign_error.rs
+++ b/src/benign_error.rs
@@ -1,0 +1,56 @@
+/// We expect some [`std::io::Error`] during regular operations:
+/// Kismet relies on the filesystem for concurrency control.
+use std::io::Error;
+use std::io::ErrorKind;
+
+/// Checks whether the error is for a missing file: NotFound, or stale
+/// handle.  A stale (NFS) handle means the inode we're trying to read
+/// isn't available on the server anymore.  Maybe we'd find something
+/// else if we flushed our client's filehandle cache, but things do go
+/// missing from caches, so gracefully treating stale handles like
+/// cache misses should be fine.
+pub fn is_absent_file_error(error: &Error) -> bool {
+    if error.kind() == ErrorKind::NotFound {
+        true
+    } else if let Some(errno) = error.raw_os_error() {
+        // We'd like to use [`ErrorKind::StaleNetworkFileHandle`],
+        // but that's not stabilised https://github.com/rust-lang/rust/issues/86442
+        errno == libc::ESTALE
+    } else {
+        false
+    }
+}
+
+// Mostly trivial, but let's at least make sure we didn't mess up raw_os_error
+// and confirm that libc agrees with what we know to be true on Linux.
+#[test]
+fn test_getters() {
+    assert_eq!(
+        true,
+        is_absent_file_error(&Error::new(ErrorKind::NotFound, "not found"))
+    );
+    assert_eq!(
+        false,
+        is_absent_file_error(&Error::new(ErrorKind::PermissionDenied, "bad"))
+    );
+
+    assert_eq!(
+        true,
+        is_absent_file_error(&Error::from_raw_os_error(libc::ENOENT))
+    );
+    assert_eq!(
+        true,
+        is_absent_file_error(&Error::from_raw_os_error(libc::ESTALE))
+    );
+    assert_eq!(
+        false,
+        is_absent_file_error(&Error::from_raw_os_error(libc::EIO))
+    );
+
+    #[cfg(target_os = "linux")]
+    assert_eq!(true, is_absent_file_error(&Error::from_raw_os_error(2))); // ENOENT
+    #[cfg(target_os = "linux")]
+    assert_eq!(true, is_absent_file_error(&Error::from_raw_os_error(116))); // ESTALE
+    #[cfg(target_os = "linux")]
+    assert_eq!(false, is_absent_file_error(&Error::from_raw_os_error(1))); // EPERM
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,7 @@
 //! is always safe for an application to store additional data in
 //! files or directories that start with a `.`, as long as they do not
 //! collide with the `.kismet` prefix.
+mod benign_error;
 mod cache_dir;
 mod multiplicative_hash;
 pub mod plain;

--- a/src/multiplicative_hash.rs
+++ b/src/multiplicative_hash.rs
@@ -3,6 +3,14 @@
 /// with `const fn` keyed constructors, and pair that with a range
 /// reduction function from `u64` to a `usize` range that extends
 /// Dietzfelbinger's power-of-two scheme.
+///
+/// For a truly faithful implementation of Dietzfelbinger's
+/// multiply-add-shift for 64-bit domain and range, we'd want 128-bit
+/// multiplier and addend.  This 64-bit version is faster and good
+/// enough for the cases we care about: we shouldn't need that many
+/// bits to assign a cache shard, and the multiplicative hash is only
+/// used as a last resort mixer to avoid really bad behaviour when the
+/// `Key`s' hashes are clusters.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct MultiplicativeHash {
     // Pseudorandom odd multiplier
@@ -11,7 +19,7 @@ pub(crate) struct MultiplicativeHash {
     addend: u64,
 }
 
-/// Maps vaues in `[0, u64::MAX]` to `[0, domain)` linearly.
+/// Maps values in `[0, u64::MAX]` to `[0, domain)` linearly.
 ///
 /// As a special case, this function returns 0 instead of erroring out
 /// when `domain == 0`.

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -193,7 +193,7 @@ fn smoke_test() {
     // The temporary garbage file must have been deleted by now.
     assert!(
         matches!(std::fs::metadata(temp.path(&format!("{}/garbage", TEMP_SUBDIR))),
-    Err(e) if e.kind() == std::io::ErrorKind::NotFound)
+                 Err(e) if e.kind() == std::io::ErrorKind::NotFound)
     );
 }
 


### PR DESCRIPTION
The write side actually worked fine (not deliberately). We also expect to see stale file handles when reaping unused files from overfull caches. Treat that like ENOENT.