### PR TITLE
Close(2) *and check the result* `NamedTempFile`s before publishing them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/pkhuong/kismet-cache"
 derivative = "2"
 extendhash = "1"
 filetime = "0.2"
+libc = "0.2"
 rand = "0.8"
 tempfile = "3"
 


### PR DESCRIPTION
We should check `close(2)` when we can: while there isn't much to do in general, we don't want to publish a file on which I/O might have failed.

Kismet's base interface works on `Path`s, so there's nothing to close; the caller must get it right if they want to check `close(2)`. We *can* do something with `NamedTempFile`s, which each bundle a File and a self-unlinking temporary path. We'll extract the File and close it, then pass the path to the regular Kismet interface.