### PR TITLE
raw_cache: add support for Amazon EFS

### DIFF
--- a/src/cache_dir.rs
+++ b/src/cache_dir.rs
@@ -125,7 +125,10 @@ pub(crate) trait CacheDir {
         target.push(name);
 
         match File::open(&target) {
-            Ok(file) => Ok(Some(file)),
+            Ok(file) => {
+                let _ = raw_cache::ensure_file_touched(&file);
+                Ok(Some(file))
+            },
             Err(e) if is_absent_file_error(&e) => Ok(None),
             Err(e) => Err(e),
         }


### PR DESCRIPTION
EFS's native relatime snaps atime to be equal to the mtime on access, so we much now check for atime >= mtime, in order to find files that were accessed.

That's OK because we already have logic to reset atime far in the past on writes, for APFS.

However, resetting atime in the past doesn't guarantee an atime update on EFS (I assume it has separate internal atime/mtime fields and updates *those* automatically with relatime).

We now check whether a newly opened file wasn't marked as touched, and explicitly snap atime forward to mtime if necessary.